### PR TITLE
Improve face detection reliability

### DIFF
--- a/scripts/utils/embed.py
+++ b/scripts/utils/embed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 import hashlib
 import os
 from pathlib import Path
@@ -29,7 +30,32 @@ def _fake_embedding(path: Path) -> np.ndarray:
     return arr / 255.0
 
 
-def image_to_embeddings(path: str | Path, model: str = "hog") -> list[np.ndarray]:
+def _normalise_upsample(upsample_times: int | Iterable[int] | None) -> list[int]:
+    """Normalise ``upsample_times`` into a list of unique integers."""
+    if upsample_times is None:
+        return [1, 2]
+    if isinstance(upsample_times, int):
+        return [upsample_times]
+
+    normalised: list[int] = []
+    seen: set[int] = set()
+    for value in upsample_times:
+        try:
+            int_value = int(value)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            continue
+        if int_value not in seen:
+            seen.add(int_value)
+            normalised.append(int_value)
+    return normalised or [1]
+
+
+def image_to_embeddings(
+    path: str | Path,
+    model: str = "hog",
+    *,
+    upsample_times: int | Iterable[int] | None = None,
+) -> list[np.ndarray]:
     """Return a list of embeddings for every detected face in ``path``."""
     image_path = Path(path)
     if not image_path.exists():
@@ -41,14 +67,23 @@ def image_to_embeddings(path: str | Path, model: str = "hog") -> list[np.ndarray
         raise RuntimeError("face_recognition library failed to import")
 
     image = fr.load_image_file(str(image_path))
-    boxes = fr.face_locations(image, model=model)
+    boxes: list[tuple[int, int, int, int]] = []
+    for upsample in _normalise_upsample(upsample_times):
+        boxes = fr.face_locations(image, number_of_times_to_upsample=upsample, model=model)
+        if boxes:
+            break
     encodings = fr.face_encodings(image, boxes)
     return [np.asarray(encoding, dtype=np.float32) for encoding in encodings]
 
 
-def encode_one_face(path: str | Path, model: str = "hog") -> np.ndarray:
+def encode_one_face(
+    path: str | Path,
+    model: str = "hog",
+    *,
+    upsample_times: int | Iterable[int] | None = None,
+) -> np.ndarray:
     """Return the first detected face embedding or raise if none are found."""
-    embeddings = image_to_embeddings(path, model=model)
+    embeddings = image_to_embeddings(path, model=model, upsample_times=upsample_times)
     if not embeddings:
         raise ValueError(f"No face found in image: {path}")
     return embeddings[0]

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+
+
+def test_image_to_embeddings_retries_with_higher_upsample(tmp_path, monkeypatch) -> None:
+    calls: list[int] = []
+
+    def fake_load_image(path: str) -> np.ndarray:  # pragma: no cover - exercised via stub
+        return np.zeros((10, 10, 3), dtype=np.uint8)
+
+    def fake_face_locations(
+        image: np.ndarray,
+        number_of_times_to_upsample: int = 1,
+        model: str = "hog",
+    ) -> list[tuple[int, int, int, int]]:
+        calls.append(number_of_times_to_upsample)
+        if number_of_times_to_upsample >= 2:
+            return [(0, 1, 2, 3)]
+        return []
+
+    def fake_face_encodings(
+        image: np.ndarray, boxes: list[tuple[int, int, int, int]]
+    ) -> list[np.ndarray]:
+        return [np.ones(128, dtype=np.float32)] if boxes else []
+
+    fake_fr = SimpleNamespace(
+        load_image_file=fake_load_image,
+        face_locations=fake_face_locations,
+        face_encodings=fake_face_encodings,
+    )
+
+    monkeypatch.setenv("FAKE_EMB", "0")
+    monkeypatch.setitem(sys.modules, "face_recognition", fake_fr)
+
+    import scripts.utils.embed as embed
+
+    embed = importlib.reload(embed)
+
+    image_path = tmp_path / "face.jpg"
+    image_path.write_bytes(b"fake")
+
+    embeddings = embed.image_to_embeddings(image_path, model="hog")
+
+    assert len(embeddings) == 1
+    assert calls == [1, 2]
+
+    # Restore module state for subsequent tests.
+    monkeypatch.setenv("FAKE_EMB", "1")
+    importlib.reload(embed)


### PR DESCRIPTION
## Summary
- retry face detection with higher upsample settings before giving up when building embeddings
- allow callers to pass custom upsample sequences through `encode_one_face`
- add a regression test that stubs `face_recognition` to ensure the retry path is exercised